### PR TITLE
Iss2 add support for 4 d nifti

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ Statistics (mean/standard deviation) can be calculated for all voxels in the .ni
 ## 1. Create a list of .nii files
 Put together a list of your .nii files and save this list as a .csv file where the header row says "input_file" and each subsequent row contains the full path to a .nii file. 
 
-If your files are 4D files and you would like to read a volume other than the first, also include a column called "volume_0basedindexing" that specifies which volume to read using 0-based indexing (e.g. use 0 to specify the first volume, 1 for the second, etc). If "volume_0basedindexing" is omitted, then the first volume of all .nii files will be used.
+If your files are 4D files and you would like to read a volume other than the first, also include a column called "volume_0basedindexing" that specifies which volume to read using 0-based indexing (e.g. use 0 to specify the first volume, 1 for the second, etc). 0-based indexing is used in the style of python, nibabel, FSL, etc.
+
+Alternately, you can specify the volume using syntax in the style of SPM, which uses 1-based indexing and writes the filename as: 
+```
+full\path\to\your.nii,V
+```
+where V indicates the volume number using 1-based indexing, e.g. `path\to\my.nii,1` for the first volume of my.nii.
+
+If volumes are specified using both SPM syntax and using a volume_0basedindexing column, the information in the volume_0basedindexing will be preferentially used. If no information is provided, the first volume of each image will be read.
 
 ## 2. Run scripts 
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,7 @@ Statistics (mean/standard deviation) can be calculated for all voxels in the .ni
 ## 1. Create a list of .nii files
 Put together a list of your .nii files and save this list as a .csv file where the header row says "input_file" and each subsequent row contains the full path to a .nii file. 
 
-These functions currently only support 3D .nii files, so only the 1st volume of each file will be read.
-
-> [!IMPORTANT]
-> The first row of the .csv must say "input_file"
+If your files are 4D files and you would like to read a volume other than the first, also include a column called "volume_0basedindexing" that specifies which volume to read using 0-based indexing (e.g. use 0 to specify the first volume, 1 for the second, etc). If "volume_0basedindexing" is omitted, then the first volume of all .nii files will be used.
 
 ## 2. Run scripts 
 

--- a/batch_niistats.py
+++ b/batch_niistats.py
@@ -47,7 +47,7 @@ def batch_niistats(input_arg: str):
 		f"{datalist_filepath}\n")
 
 	# read it and check for missing files
-	datalist = pd.read_csv(datalist_filepath)
+	datalist = utilities.load_datalist(datalist_filepath)
 	valid_files = {f for f in datalist['input_file'] if os.path.exists(f)}
 
 	##########################################################################

--- a/batch_niistats.py
+++ b/batch_niistats.py
@@ -58,7 +58,7 @@ def batch_niistats(input_arg: str):
 			filter(
 				None, 
 				executor.map(
-					lambda args: nii.try_single_nii_calc(args[0],args[1],inputs,valid_files),
+					lambda args: nii.single_nii_calc(args[0],args[1],inputs,valid_files),
 					zip(datalist['input_file'],datalist['volume_0basedindex'])
 			)
 		

--- a/batch_niistats.py
+++ b/batch_niistats.py
@@ -58,11 +58,8 @@ def batch_niistats(input_arg: str):
 			filter(
 				None, 
 				executor.map(
-					lambda nii_file: nii.single_nii_calc(nii_file, 
-													inputs,
-													valid_files),
-					datalist['input_file'])
-					)
+					lambda args: nii.try_single_nii_calc(args[0],args[1],inputs,valid_files),
+					zip(datalist['input_file'],datalist['volume_0basedindex'])
 			)
 		
 	##########################################################################

--- a/src/modules/nii.py
+++ b/src/modules/nii.py
@@ -11,19 +11,22 @@
 
 import nibabel as nb
 import numpy as np
+from typing import Optional, Union, Dict, Set
 
-def load_nii(input_file: str) -> np.ndarray:
+def load_nii(input_file: str,
+             nii_volume: int) -> np.ndarray:
 
-    """ Call nibabel to load first volumn of .nii file
+    """ Call nibabel to load a volume of .nii file
 
-    We can't assume that array is 2D, so load to array and check. 
-    Returns a 3-D array.
+    Load a volume from a .nii file using nibabel.
+    Returns a 3D NumPy array.
 
     """
     img_proxy = nb.load(input_file)
     data_array = np.asarray(img_proxy.get_fdata())
+    
     if data_array.ndim == 4:
-        data_array = data_array[...,0] #get only first volume
+        data_array = data_array[...,nii_volume] #get only first volume
     
     return(data_array)
 
@@ -51,9 +54,11 @@ def sd_nii(data_array: np.ndarray,
     
     return value
 
-def single_nii_calc(nii_file: list[str],
-                            inputs: dict[bool,str],
-                            valid_files: list[str]) -> dict[str, float]:
+def single_nii_calc(nii_file: str,
+                    nii_volume: str,
+                    inputs: Dict[str, Union[bool, str]],
+                    valid_files: Set[str]
+                    ) -> Dict[str, Union[str, int, float]]:
     
     """Calculate statistics for a single .nii file, to be used with map
     
@@ -73,7 +78,7 @@ def single_nii_calc(nii_file: list[str],
 
     # Run calculation only if the file exists
     if nii_file in valid_files:
-        nii_array = load_nii(nii_file)
+        nii_array = load_nii(nii_file,nii_volume)
 
         if inputs["statistic"] == 'mean':
             output_val = mean_nii(nii_array, inputs["omit_zeros"])

--- a/src/modules/utilities.py
+++ b/src/modules/utilities.py
@@ -52,7 +52,18 @@ def askfordatalist(*args) -> str:
   root.withdraw()
   datalist_filepath = filedialog.askopenfilename()
   return datalist_filepath
+def load_datalist(datalist_filepath: str) -> pd.DataFrame:
 
+	"""
+    Loads a CSV file containing paths to .nii files and optional volume indices.
+
+    """
+	datalist = pd.read_csv(datalist_filepath)
+
+	if 'volume_0basedindex' not in datalist.columns:
+		datalist['volume_0basedindex'] = 0
+
+	return datalist
 def report_usage(*args) -> str:
    """ Defines the text used to repor usage to the user
    

--- a/src/modules/utilities.py
+++ b/src/modules/utilities.py
@@ -126,17 +126,33 @@ def load_datalist(datalist_filepath: str) -> pd.DataFrame:
 	return prioritize_volume(datalist)
 
 def report_usage(*args) -> str:
-   """ Defines the text used to repor usage to the user
-   
-   """
-   usage_text = ("\nUsage: python batch_niistats.py [option]\n\n"
-				"Options:\n\n-M: output mean (for nonzero voxels only)\n"
-				"-m: output mean (for all voxels in image)\n\nYou will then "
-				"be prompted for a list of .nii files to process.\nThis list "
-				"must be a single-column csv file where the first row\nsays "
-				"'input_file' and the subsequent rows are absolute paths\nto "
-				"each file.")
-   print(usage_text.format())
+	
+	"""
+    Prints usage information to the terminal.
+    """
+	usage_text = (
+		"\nUsage: python batch_niistats.py [option]\n\n"
+		"Options:\n\n"
+		"-M: output mean (for nonzero voxels only)\n"
+		"-m: output mean (for all voxels in image)\n"
+		"-S: output standard deviation (for nonzero voxels only)\n"
+		"-s: output standard deviation (for all voxels)\n\n"
+		"You will then be prompted for a list of .nii files to process.\n\n"
+		"This list must be a CSV file with columns 'input_file' and\n"
+		"'volume_0basedindexing'.\n\n"
+		"'input_file' lists the absolute paths to each .nii file and\n"
+		"'volume_0basedindexing' indicates the volume to read, using\n"
+		"0-based indexing (e.g. use 0 to specify the first volume and 1\n"
+		"for the second, etc).\n\n"
+		"In lieu of a 'volume_0basedindex' column, volumes can also be\n"
+		"specified in the input_file column using SPM syntax where ',N' is\n"
+		"placed after the filename. N indicates volume using 1-based indexing.\n\n"
+		"The 'volume_0basedindexing' column or SPM synax can be omitted if\n"
+		"all files are 3D NIfTIs or if you only want to calculate statistics\n"
+		"on the first volume of each image.\n\n"
+		)
+	
+	print(usage_text.format())
 
 def save_output_csv(output_df: pd.DataFrame, 
                     datalist_filepath: str,


### PR DESCRIPTION
# Description

These change modify the code so that it will read and run calculations on 4D niftis. Fixes #2.

# Details
The user can now specify which volume to calculate for each file. Only 1 statistic is calculated per volume, so 4D files will need to have each volume specified as separate rows in the input .csv file, but there is now a way to specify which volume to read in the .csv file. This can be done either by denoting the volume in a separate column, or using SPM-style syntax. Changes include:

- updated readme and other documentation
- added subfunctions that will parse SPM-style syntax and, if conflicts, will defer to the user-provided column
- changed inputs to functions so that volume is provided as an input to load_nii