### PR TITLE
Iss25 clean up save output csv

### DIFF
--- a/src/batch_niistats/cli.py
+++ b/src/batch_niistats/cli.py
@@ -9,85 +9,85 @@ import concurrent.futures
 
 
 def main():
-	"""Calculate statistics for batch of .nii files and save .csv of output
+    """Calculate statistics for batch of .nii files and save .csv of output
 
-	Function to calculate statistics for a set of nifti iamges and save a 
-	.csv file with the output. Which statistic to be calculated, and 
-	whether all voxels or only nonzero voxels are included, is specified
-	via input args. Supported inputs are S, s, M, m and follow FSL's
-	conventions for input options.
+    Function to calculate statistics for a set of nifti iamges and save a 
+    .csv file with the output. Which statistic to be calculated, and 
+    whether all voxels or only nonzero voxels are included, is specified
+    via input args. Supported inputs are S, s, M, m and follow FSL's
+    conventions for input options.
 
-	This function prompts the user for the csv file that contains input 
-	.nii files (which was used in the bash script), and then compiles the 
-	output into a csv file. 
+    This function prompts the user for the csv file that contains input 
+    .nii files (which was used in the bash script), and then compiles the 
+    output into a csv file. 
 
-	For details & issues, see https://github.com/mcclaskey/batch_niistats.
+    For details & issues, see https://github.com/mcclaskey/batch_niistats.
 
-	CMcC 4.9.2025
-	"""
+    CMcC 4.9.2025
+    """
 
-	##########################################################################
-	# handle input arguments
-	##########################################################################
-	parser = argparse.ArgumentParser(
+    ##########################################################################
+    # handle input arguments
+    ##########################################################################
+    parser = argparse.ArgumentParser(
         description=(f"Calculate statistics from a list of .nii files.\n\n"
-		f"Once the program starts, you will prompted for a list of .nii\n"
-		f"files to process. This list must be a CSV file with columns\n"
-		f"'input_file' and (optionally) 'volume_0basedindexing'.\n\n"
-		f"'input_file' lists the absolute paths to each .nii file and\n"
-		f"'volume_0basedindexing' indicates the volume to read, using\n"
-		f"0-based indexing (e.g. use 0 to specify the first volume and 1\n"
-		f"for the second, etc).\n\n"
-		f"In lieu of a 'volume_0basedindex' column, volumes can also be\n"
-		f"specified in the input_file column using SPM syntax where ',N' is\n"
-		f"placed after the filename. N indicates volume using 1-based indexing.\n\n"
-		f"The 'volume_0basedindexing' column or SPM synax can be omitted if\n"
-		f"all files are 3D NIfTIs or if you only want to calculate statistics\n"
-		f"on the first volume of each image.\n\n"),
-		formatter_class=argparse.RawDescriptionHelpFormatter,
+        f"Once the program starts, you will prompted for a list of .nii\n"
+        f"files to process. This list must be a CSV file with columns\n"
+        f"'input_file' and (optionally) 'volume_0basedindexing'.\n\n"
+        f"'input_file' lists the absolute paths to each .nii file and\n"
+        f"'volume_0basedindexing' indicates the volume to read, using\n"
+        f"0-based indexing (e.g. use 0 to specify the first volume and 1\n"
+        f"for the second, etc).\n\n"
+        f"In lieu of a 'volume_0basedindex' column, volumes can also be\n"
+        f"specified in the input_file column using SPM syntax where ',N' is\n"
+        f"placed after the filename. N indicates volume using 1-based indexing.\n\n"
+        f"The 'volume_0basedindexing' column or SPM synax can be omitted if\n"
+        f"all files are 3D NIfTIs or if you only want to calculate statistics\n"
+        f"on the first volume of each image.\n\n"),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-	parser.add_argument(
+    parser.add_argument(
         "option",
         choices=["M", "m", "S", "s"],
         help="Statistical option: M (mean, nonzero), m (mean, all), "
              "S (sd, nonzero), s (sd, all)"
     )
 
-	args = parser.parse_args()
+    args = parser.parse_args()
 
-	##########################################################################
-	# start with basic info: ask user for csv, report, check files
-	##########################################################################
+    ##########################################################################
+    # start with basic info: ask user for csv, report, check files
+    ##########################################################################
 
-	# parse inputs
-	inputs = utils.parse_inputs(args.option)
+    # parse inputs
+    inputs = utils.parse_inputs(args.option)
 
-	# ask for datalist (csv, first row must be "input_file")
-	datalist_filepath = utils.askfordatalist()
+    # ask for datalist (csv, first row must be "input_file")
+    datalist_filepath = utils.askfordatalist()
 
-	# print info for user reference
-	timestamp = utils.get_timestamp()
-	print(f"[{timestamp}] batch_niistats.py\n\nCompiling .csv file with "
-		f"{inputs['statistic']} values of .nii files listed in:\n"
-		f"{datalist_filepath}\n")
+    # print info for user reference
+    timestamp = utils.get_timestamp()
+    print(f"[{timestamp}] batch_niistats.py\n\nCompiling .csv file with "
+        f"{inputs['statistic']} values of .nii files listed in:\n"
+        f"{datalist_filepath}\n")
 
-	# read it and check for missing files
-	datalist = utils.load_datalist(datalist_filepath)
-	valid_files = {f for f in datalist['file'] if os.path.exists(f)}
+    # read it and check for missing files
+    datalist = utils.load_datalist(datalist_filepath)
+    valid_files = {f for f in datalist['file'] if os.path.exists(f)}
 
-	##########################################################################
-	# Loop across rows in csv, call single_nii_calc, add result to list
-	##########################################################################
-	with concurrent.futures.ThreadPoolExecutor() as executor:
-		single_nii_results = executor.map(
-			lambda args: nii.try_single_nii_calc(args[0],args[1],args[2],inputs,valid_files),
-			zip(datalist['input_file'],datalist['file'],datalist['volume_0basedindex'])
-			)
-		list_of_data = list(single_nii_results)
-	
-	##########################################################################
-	# create dataframe, show to user, save to csv, end program
-	##########################################################################
+    ##########################################################################
+    # Loop across rows in csv, call single_nii_calc, add result to list
+    ##########################################################################
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        single_nii_results = executor.map(
+            lambda args: nii.try_single_nii_calc(args[0],args[1],args[2],inputs,valid_files),
+            zip(datalist['input_file'],datalist['file'],datalist['volume_0basedindex'])
+            )
+        list_of_data = list(single_nii_results)
+    
+    ##########################################################################
+    # create dataframe, show to user, save to csv, end program
+    ##########################################################################
     output_path = utils.write_output_df_path(datalist_filepath,
                                           args.option,
                                           timestamp)
@@ -98,4 +98,4 @@ def main():
     return(combined_df)
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/src/batch_niistats/cli.py
+++ b/src/batch_niistats/cli.py
@@ -88,13 +88,14 @@ def main():
 	##########################################################################
 	# create dataframe, show to user, save to csv, end program
 	##########################################################################
-	combined_df = utils.create_output_df(datalist,list_of_data)
-	utils.save_output_csv(combined_df,
-							datalist_filepath,
-							args.option,
-							timestamp)
-	
-	return(combined_df)
+    output_path = utils.write_output_df_path(datalist_filepath,
+                                          args.option,
+                                          timestamp)
+    combined_df = utils.create_output_df(datalist,list_of_data)
+    combined_df.to_csv(output_path, index=False)
+    print(f"\nOutput saved to file:\n{output_path}\n")
+    
+    return(combined_df)
 
 if __name__ == "__main__":
 	main()

--- a/src/batch_niistats/cli.py
+++ b/src/batch_niistats/cli.py
@@ -92,8 +92,7 @@ def main():
                                           args.option,
                                           timestamp)
     combined_df = utils.create_output_df(datalist,list_of_data)
-    combined_df.to_csv(output_path, index=False)
-    print(f"\nOutput saved to file:\n{output_path}\n")
+    utils.save_output_csv(combined_df,output_path)
     
     return(combined_df)
 

--- a/src/batch_niistats/modules/utils.py
+++ b/src/batch_niistats/modules/utils.py
@@ -156,7 +156,7 @@ def create_output_df(datalist: pd.DataFrame,
 
 def write_output_df_path(datalist_filepath: str,
                          statistic: str,
-                         timestamp: str):
+                         timestamp: str) -> str:
     """Create name and full filepath for output .csv 
     
     Output file will be in the same directory as input .csv.

--- a/src/batch_niistats/modules/utils.py
+++ b/src/batch_niistats/modules/utils.py
@@ -172,3 +172,8 @@ def write_output_df_path(datalist_filepath: str,
 
     return(output_path)
 
+def save_output_csv(output_df: pd.DataFrame,
+                    output_path: str):
+    """Saves output csv to file path"""
+    output_df.to_csv(output_path, index=False)
+    print(f"\nOutput saved to file:\n{output_path}\n")

--- a/src/batch_niistats/modules/utils.py
+++ b/src/batch_niistats/modules/utils.py
@@ -2,12 +2,12 @@
 # -*- coding : utf-8 -*-
 
 """
-	Functions for basic utilities, such as path lookups and reading 
-	input files.
-		
-	Part of batch_niistats package.
+    Functions for basic utilities, such as path lookups and reading 
+    input files.
+        
+    Part of batch_niistats package.
 
-	CMcC 4/21/2025 github: https://github.com/mcclaskey/batch_niistats. 
+    CMcC 4/21/2025 github: https://github.com/mcclaskey/batch_niistats. 
 
 """
 
@@ -24,122 +24,122 @@ def get_timestamp() -> str:
 
 def parse_inputs(input_arg: str) -> dict[str, bool | str] | None:
     """Parse user-provided input options
-	
+    
     Reads the user-provided option and defines the statistic
-	and whether to use all voxels or only non-zero voxels, 
-	then returns this as a dict.
+    and whether to use all voxels or only non-zero voxels, 
+    then returns this as a dict.
 
     Supported options are:
-	M: calculate mean of nonzero voxels
-	m: calculate mean of all voxels
-	S: calculate standard deviation of nonzero voxels
-	s: calculate standard deivation of all voxels
-	"""
-	
+    M: calculate mean of nonzero voxels
+    m: calculate mean of all voxels
+    S: calculate standard deviation of nonzero voxels
+    s: calculate standard deivation of all voxels
+    """
+    
     option_map = {
         "M": {"omit_zeros": True, "statistic": "mean"},
         "m": {"omit_zeros": False, "statistic": "mean"},
         "S": {"omit_zeros": True, "statistic": "sd"},
         "s": {"omit_zeros": False, "statistic": "sd"},
     }
-	
+    
     return option_map.get(input_arg, {})
 
 
 def askfordatalist() -> str:
-	"""Prompt user for input CSV file and return full file path as string."""
-	root = tk.Tk()
-	root.withdraw()
-	return filedialog.askopenfilename()
+    """Prompt user for input CSV file and return full file path as string."""
+    root = tk.Tk()
+    root.withdraw()
+    return filedialog.askopenfilename()
 
 
 def comma_split(input_spm_path: str) -> dict[str, int | None]:
-	"""Split SPM-style path at comma, return file and 0-based vol as dict"""
-	parts = input_spm_path.split(',')
-	if len(parts) > 1 and parts[1].isdigit():
-		volume_index  = int(parts[1]) - 1
-	else:
-		volume_index  = None
-		
+    """Split SPM-style path at comma, return file and 0-based vol as dict"""
+    parts = input_spm_path.split(',')
+    if len(parts) > 1 and parts[1].isdigit():
+        volume_index  = int(parts[1]) - 1
+    else:
+        volume_index  = None
+        
 
-	return {'file': parts[0],'volume_spm_0basedindex': volume_index }
+    return {'file': parts[0],'volume_spm_0basedindex': volume_index }
 
 def parse_spmsyntax(datalist: pd.DataFrame) -> pd.DataFrame:
-	"""Handle SPM-style volume syntax in 'input_file' column
+    """Handle SPM-style volume syntax in 'input_file' column
 
     Takes .csv datalist and reads the "input_file" column according to SPM
-	syntax for specifying volumes. Returns a dataframe where the input_file
-	column is converted to a pure filepath and a new 0-based index column
-	containing the SPM volume is added.
+    syntax for specifying volumes. Returns a dataframe where the input_file
+    column is converted to a pure filepath and a new 0-based index column
+    containing the SPM volume is added.
     """
 
-	list_of_spmsplit = list(map(comma_split,datalist['input_file']))
-	df_of_spmsplits = pd.DataFrame(list_of_spmsplit)
+    list_of_spmsplit = list(map(comma_split,datalist['input_file']))
+    df_of_spmsplits = pd.DataFrame(list_of_spmsplit)
 
-	return pd.concat([datalist, df_of_spmsplits], axis=1)
+    return pd.concat([datalist, df_of_spmsplits], axis=1)
 
 def prioritize_volume(datalist):
-	"""Determine which volume to read for each file given input info
-	
-	Reads datalist with potentially multiple volumn columns and resolves 
-	conflicting or missing values. Determines which volume to read according
-	to rules and returns a dataframe with only two columns: 'input_file' which
-	has only a pure file path to .nii, and 'volume_0basedindex' column.
+    """Determine which volume to read for each file given input info
+    
+    Reads datalist with potentially multiple volumn columns and resolves 
+    conflicting or missing values. Determines which volume to read according
+    to rules and returns a dataframe with only two columns: 'input_file' which
+    has only a pure file path to .nii, and 'volume_0basedindex' column.
 
     Preference order: explicit volume col > SPM syntax > default to first vol.
     """
-	
-	# temp var
-	datalist['volume'] = None	
-	
-	# uses matching volume
-	matches = datalist['volume_spm_0basedindex'] == datalist['volume_0basedindex']
-	datalist.loc[matches,'volume'] = datalist.loc[matches,'volume_0basedindex']
+    
+    # temp var
+    datalist['volume'] = None	
+    
+    # uses matching volume
+    matches = datalist['volume_spm_0basedindex'] == datalist['volume_0basedindex']
+    datalist.loc[matches,'volume'] = datalist.loc[matches,'volume_0basedindex']
 
-	# if conflicts, preferentially read from user created column 'volume_0basedindex'
-	user_vol = ~np.isnan(datalist.loc[~matches, 'volume_0basedindex'])
-	datalist.loc[~matches & user_vol, 'volume'] = datalist.loc[~matches & user_vol, 'volume_0basedindex']
+    # if conflicts, preferentially read from user created column 'volume_0basedindex'
+    user_vol = ~np.isnan(datalist.loc[~matches, 'volume_0basedindex'])
+    datalist.loc[~matches & user_vol, 'volume'] = datalist.loc[~matches & user_vol, 'volume_0basedindex']
 
-	# if missingness, read from spm
-	missingrows = datalist['volume'].isna()
-	spm_vol = ~np.isnan(datalist.loc[missingrows,'volume_spm_0basedindex'])
-	datalist.loc[missingrows & spm_vol ,'volume'] = datalist.loc[missingrows & spm_vol ,'volume_spm_0basedindex']
+    # if missingness, read from spm
+    missingrows = datalist['volume'].isna()
+    spm_vol = ~np.isnan(datalist.loc[missingrows,'volume_spm_0basedindex'])
+    datalist.loc[missingrows & spm_vol ,'volume'] = datalist.loc[missingrows & spm_vol ,'volume_spm_0basedindex']
 
-	# if missing, assume first volume
-	datalist.loc[datalist['volume'].isna(), 'volume'] = 0  # default to first volume
-	datalist['volume_0basedindex'] = datalist['volume'].astype(int)
-	return datalist.drop(columns=['volume_spm_0basedindex', 'volume'], errors='ignore')
+    # if missing, assume first volume
+    datalist.loc[datalist['volume'].isna(), 'volume'] = 0  # default to first volume
+    datalist['volume_0basedindex'] = datalist['volume'].astype(int)
+    return datalist.drop(columns=['volume_spm_0basedindex', 'volume'], errors='ignore')
 
 
 def load_datalist(datalist_filepath: str) -> pd.DataFrame:
-	"""Load user-specified input .csv file and return formatting dataframe
-	
-	Loads a CSV file containing paths to .nii files and optional volume indices.
+    """Load user-specified input .csv file and return formatting dataframe
+    
+    Loads a CSV file containing paths to .nii files and optional volume indices.
 
     Handles SPM-style syntax and fills in missing volume data. Resolves conflicting
-	input information and defaults to first volume where necessary. 
+    input information and defaults to first volume where necessary. 
 
-	Returns a dataframe with 'input_file' as pure absolute paths to .nii files 
-	and 'volume_0basedindex' column with volume indices. Other columns in the
-	datalist, if existing, are left unmodified.
+    Returns a dataframe with 'input_file' as pure absolute paths to .nii files 
+    and 'volume_0basedindex' column with volume indices. Other columns in the
+    datalist, if existing, are left unmodified.
     """
-	datalist = pd.read_csv(datalist_filepath)
+    datalist = pd.read_csv(datalist_filepath)
 
-	# now check for SPM volume syntax
-	if datalist['input_file'].astype(str).str.contains(',').any():
-		datalist = parse_spmsyntax(datalist)
-	else:
-		datalist['file'] = datalist['input_file']
-		datalist['volume_spm_0basedindex'] = np.nan
+    # now check for SPM volume syntax
+    if datalist['input_file'].astype(str).str.contains(',').any():
+        datalist = parse_spmsyntax(datalist)
+    else:
+        datalist['file'] = datalist['input_file']
+        datalist['volume_spm_0basedindex'] = np.nan
 
-	if 'volume_0basedindex' not in datalist.columns:
-		datalist['volume_0basedindex'] = np.nan
+    if 'volume_0basedindex' not in datalist.columns:
+        datalist['volume_0basedindex'] = np.nan
 
-	return prioritize_volume(datalist)
+    return prioritize_volume(datalist)
 
 def create_output_df(datalist: pd.DataFrame,
-					 list_of_data:list) -> pd.DataFrame:
-	
+                     list_of_data:list) -> pd.DataFrame:
+    
     """Merges input and output df and returns df with original index order"""
     calculated_df = pd.DataFrame(list_of_data)
     calculated_df['input_file'] = calculated_df['input_file'].str.strip()
@@ -151,7 +151,7 @@ def create_output_df(datalist: pd.DataFrame,
 
     combined_df = input_df.merge(calculated_df, on = ['input_file','index'], how='outer', sort = False)
     combined_df = combined_df.sort_values(by='index').drop(columns=["index"], axis=1).reset_index(drop=True)
-	
+    
     return combined_df
 
 def write_output_df_path(datalist_filepath: str,
@@ -162,13 +162,13 @@ def write_output_df_path(datalist_filepath: str,
     Output file will be in the same directory as input .csv.
     File name includes the timestamp and statistic.
     """
-	
-	timestamp_dt = datetime.datetime.strptime(timestamp,"%Y.%m.%d %H:%M:%S")
-	timestamp_file = timestamp_dt.strftime("%Y%m%d_%H%M%S")
-	statistic_clean = statistic.replace('-', '')
+    
+    timestamp_dt = datetime.datetime.strptime(timestamp,"%Y.%m.%d %H:%M:%S")
+    timestamp_file = timestamp_dt.strftime("%Y%m%d_%H%M%S")
+
+    output_dir = os.path.dirname(datalist_filepath)
+    base_name = os.path.basename(datalist_filepath).replace('.csv', f'_calc_{statistic}.csv')
+    output_path = os.path.join(output_dir, f"{timestamp_file}_{base_name}")
 
     return(output_path)
-	output_dir = os.path.dirname(datalist_filepath)
-	base_name = os.path.basename(datalist_filepath).replace('.csv', f'_calc_{statistic_clean}.csv')
-	output_path = os.path.join(output_dir, f"{timestamp_file}_{base_name}")
 

--- a/src/batch_niistats/modules/utils.py
+++ b/src/batch_niistats/modules/utils.py
@@ -154,12 +154,12 @@ def create_output_df(datalist: pd.DataFrame,
 	
     return combined_df
 
-def save_output_csv(output_df: pd.DataFrame, 
-					datalist_filepath: str,
-					statistic: str,
-					timestamp: str):
-	"""Save data to output .csv in the same directory as input .csv
-
+def write_output_df_path(datalist_filepath: str,
+                         statistic: str,
+                         timestamp: str):
+    """Create name and full filepath for output .csv 
+    
+    Output file will be in the same directory as input .csv.
     File name includes the timestamp and statistic.
     """
 	
@@ -167,9 +167,8 @@ def save_output_csv(output_df: pd.DataFrame,
 	timestamp_file = timestamp_dt.strftime("%Y%m%d_%H%M%S")
 	statistic_clean = statistic.replace('-', '')
 
+    return(output_path)
 	output_dir = os.path.dirname(datalist_filepath)
 	base_name = os.path.basename(datalist_filepath).replace('.csv', f'_calc_{statistic_clean}.csv')
 	output_path = os.path.join(output_dir, f"{timestamp_file}_{base_name}")
 
-	output_df.to_csv(output_path, index=False)
-	print(f"\nOutput saved to file:\n{output_path}\n")


### PR DESCRIPTION
# Description

These changes fix the code at the end of utils.py that creates a name for the output dataframe and saves it, then reports to the user. That functionality is now performed by two separate functions. Fixes #25. 

# Details
- `save_output_csv` was converted to `write_output_df_path` and now _only_ creates the output filepath
- a new `save_output_csv` was defined that now saves the file and reports the location to the user
- `cli.py` was modified to first call `write_output_df_path`, then call `save_output_csv` 
- indentation was formally changed to spaces instead of tabs to adhere to PEP