### PR TITLE
test fix for codecov

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,12 +38,10 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
-        pytest --cov=src --cov-report=term-missing --cov-report=xml
-
+        pytest --cov=batch_niistats --cov-report=term-missing --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
       with:
         files: coverage.xml
-        flags: unittests  # Optional, flag for the type of tests
         fail_ci_if_error: false  # Set to true to fail CI on upload error
     

--- a/src/batch_niistats/cli.py
+++ b/src/batch_niistats/cli.py
@@ -111,5 +111,5 @@ def main():
     return combined_df
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
# Description

This change attempts to fix a code cov bug where tests aren't run for, by specifying the package name and removing unittests flag. Since this also misses a test on name==main, that line is omitted from testing. Related to #28.