### PR TITLE
update readme and argparser to provide clearer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ The program will start by opening a file selection dialogue box. Select the .csv
 When it is done you will have a .csv file in the same directory as the input .csv file. This output file will have the same base name as the input file but will also be prepended with a timestamp and appended with a suffix that denotes the option specified as input. 
 
 # How to install
-You can install `batch_niistats` from the source repository with the command `pip install git+https://github.com/mcclaskey/batch_niistats.git@main` or by cloning the repository and installing from the local directory (recommended). It is highly recommended that you run the install (by either method) inside a virtual environment (see below). 
+You can install `batch_niistats` from the source repository with the command `pip install git+https://github.com/mcclaskey/batch_niistats.git@main` or by cloning the repository and installing from the local directory (recommended). 
+
+It is highly recommended that you run the install (by either method) inside a virtual environment (see below). 
 
 To install from a local directory, first cd to where you store all repos, create or activate your project environment (if using), and run the following:
 ```
@@ -69,7 +71,7 @@ pip install -e .
 ```
 
 ### A note on virtual environments if you are new to python's venv (disclaimer: personal opinions included)
-If you don't already have a way to manage python environments and are looking to find one, I highly recommend Doug Hellmann's [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) tool. It's a user-friendly wrapper for virtualenv that organizes all your environments for you and makes them easy to work with. 
+If you don't already have a way to manage python environments and are looking to find one, I highly recommend Doug Hellmann's [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) tool. It's a clean, organized, and user-friendly wrapper for Ian Bicking's [virtualenv](https://pypi.org/project/virtualenv/) that stores all your environments in one place and makes them easy to work with. 
 
 Conda/Anaconda also provide tools for environment management, although I generally find these more difficult to use unless you work with them every day (in which case you probably don't need advice on venv). 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-[![codecov](https://codecov.io/gh/mcclaskey/batch_niistats/branch/main/graph/badge.svg)](https://codecov.io/gh/mcclaskey/batch_niistats)
+# batch_niistats: calculate stats on a batch of .nii files
+![Python Versions](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-blue) [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE) [![batch_niistats-tests](https://img.shields.io/github/actions/workflow/status/mcclaskey/batch_niistats/python-package.yml?label=batch_niistats-tests&logo=github)](https://github.com/mcclaskey/batch_niistats/actions/workflows/python-package.yml)
+ [![codecov](https://codecov.io/gh/mcclaskey/batch_niistats/branch/main/graph/badge.svg)](https://codecov.io/gh/mcclaskey/batch_niistats)
 
-# batch_niistats
+
+
+
+
 Small set of functions that calculate statistics on a batch of 3D nifti files and return the output as a .csv file. Pure python code that works very quickly on all operating systems.
 
 Statistics (mean/standard deviation) can be calculated for all voxels in the .nii, or for only nonzero voxels. This is the equivalent of fslstats with the -M/-S option or -m/-s option, respectively.
@@ -27,7 +32,7 @@ If volumes are specified using both SPM syntax and using a `volume_0basedindex` 
 
 ## 2. Run scripts 
 
-Open a terminal (in unix/linux/WSL) or command prompt (in Windows). Activate your project environment and cd to the project directory, then run the following line:
+Open a terminal (in unix/linux/WSL) or command prompt (in Windows), activate your virtual environment (if necessary), then run the following:
 ```
 batch_niistats [option]
 ```
@@ -47,14 +52,22 @@ The program will start by opening a file selection dialogue box. Select the .csv
 
 When it is done you will have a .csv file in the same directory as the input .csv file. The output file's name will be be the same as the input file's name but will have a timestamp and the suffix that indicates the option specified as input. 
 
-# Setup 
-## Basic Steps
-1. create/activate a project environment
-2. cd to where you store repos and clone this repo using ```git clone https://github.com/mcclaskey/batch_niistats.git```
-3. cd to repo directory
-4. run `pip install -e .` to install required packages into your environment
+# How to install
+You can install `batch_niistats` from the source repository with the command `pip install git+https://github.com/mcclaskey/batch_niistats.git@main` or by cloning the repository and installing from the local directory (recommended). To install from a local directory, first cd to where you store all repos and run the following:
+```
+git clone https://github.com/mcclaskey/batch_niistats.git
+cd batch_niistats
+pip install -e .
+```
+If you used a local install, you can easily update the code at a later date using the following lines:
 
-## venv
+```
+git pull
+pip install -e .
+```
+
+It is highly recommended that you run the install (by either method) inside a virtual environment. 
+
 If you do not have a way to manage environments, here is a quick way to create and activate a python environment for this project:
 
 Create the environment (do this only once):

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
 
 
 
-Small set of functions that calculate statistics on a batch of 3D nifti files and return the output as a .csv file. Pure python code that works very quickly on all operating systems.
+Small set of functions that calculate statistics on a batch of 3D NIfTI files and return the output as a .csv file. Pure python code that works very quickly on all operating systems.
 
-Statistics (mean/standard deviation) can be calculated for all voxels in the .nii, or for only nonzero voxels. This is the equivalent of fslstats with the -M/-S option or -m/-s option, respectively.
+Statistics (mean/standard deviation) can be calculated for all voxels in the nifti, or for only nonzero voxels. This is the equivalent of fslstats with the -M/-S option or -m/-s option, respectively.
 
 # Requirements
 * python3.11+
 
 # Instructions
 
-## 1. Create a list of .nii files
-Put together a list of your .nii files and save this list as a .csv file where the header row says `input_file` and each subsequent row contains the full path to a .nii file. 
+## 1. Create a list of NIfTI files
+Put together a list of your NIfTI files and save this list as a .csv file where the header row says `input_file` and each subsequent row contains the full path to a NIfTI file. `batch_niistats` can read both zipped (.nii.gz) and unzipped (.nii) NIfTI files.
 
-If your files are 4D files and you would like to read a volume other than the first, also include a column called `volume_0basedindex` that specifies which volume to read using 0-based indexing (e.g. use 0 to specify the first volume, 1 for the second, etc). 0-based indexing is used in the style of python, nibabel, FSL, etc. To read multiple volumes/timepoints of a 4D .nii file, list each volume as a separate row in the input datalist.
+If your files are 4D files and you would like to read a volume other than the first, also include a column called `volume_0basedindex` that specifies which volume to read using 0-based indexing (e.g. use 0 to specify the first volume, 1 for the second, etc). 0-based indexing is used in the style of python, nibabel, FSL, etc. To read multiple volumes/timepoints of a 4D nifti file, list each volume as a separate row in the input datalist.
 
 Alternately, you can specify the volume using SPM-style syntax in the contents of the `input_file` column, as follows: 
 ```
@@ -26,7 +26,7 @@ full\path\to\your.nii,V
 ```
 where V is an integer that indicates the volume number using 1-based indexing, e.g. `path\to\my.nii,1` for the first volume of my.nii. 
 
-Support for SPM syntax is intended to facilitate copying to and from SPM but is otherwise not recommended. If you define filenames in this way, omit single quotations at the start and end of each string that are sometimes retained during SPM copy/paste. `batch_niistats.py` will not strip single quotations from file paths because they could theoretically be part of the file name.
+Support for SPM syntax is intended to facilitate copying to and from SPM but is otherwise not recommended. If you define filenames in this way, omit single quotations at the start and end of each string that are sometimes retained during SPM copy/paste. `batch_niistats` will not strip single quotations from file paths because they could theoretically be part of the file name.
 
 If volumes are specified using both SPM syntax and using a `volume_0basedindex` column, the information in the `volume_0basedindex` column will be preferentially used. If no information is provided, the first volume of each image will be read.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ batch_niistats M
 
 The program will start by opening a file selection dialogue box. Select the .csv file you created in step 1 and press ok. Wait while the program runs.
 
-When it is done you will have a .csv file in the same directory as the input .csv file. The output file's name will be be the same as the input file's name but will have a timestamp and the suffix that indicates the option specified as input. 
+When it is done you will have a .csv file in the same directory as the input .csv file. This output file will have the same base name as the input file but will also be prepended with a timestamp and appended with a suffix that denotes the option specified as input. 
 
 # How to install
 You can install `batch_niistats` from the source repository with the command `pip install git+https://github.com/mcclaskey/batch_niistats.git@main` or by cloning the repository and installing from the local directory (recommended). To install from a local directory, first cd to where you store all repos and run the following:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ full\path\to\your.nii,V
 ```
 where V is an integer that indicates the volume number using 1-based indexing, e.g. `path\to\my.nii,1` for the first volume of my.nii. 
 
-Support for SPM syntax is intended to facilitate copying to and from SPM but is otherwise not recommended. If you define filenames in this way, omit single quotations at the start and end of each string that are sometimes retained during SPM copy/paste. `batch_niistats` will not strip single quotations from file paths because they could theoretically be part of the file name.
+Support for SPM syntax is intended to facilitate copying to and from SPM but is otherwise not recommended. If you define filenames in this way, omit single quotations at the start and end of each string that are sometimes retained during SPM copy/paste. `batch_niistats` does not strip single quotations from file paths because they could be valid characters in some filenames.
 
 If volumes are specified using both SPM syntax and using a `volume_0basedindex` column, the information in the `volume_0basedindex` column will be preferentially used. If no information is provided, the first volume of each image will be read.
 
@@ -48,7 +48,7 @@ For example, to calculate mean across only nonzero voxels, type:
 batch_niistats M
 ```
 
-The program will start by opening a file selection dialogue box. Select the .csv file you created in step 1 and press ok. Wait while the program runs.
+The program will start by opening a file selection dialogue box. Select the .csv file you created in step 1 and press ok. Wait for the program to finish.
 
 When it is done you will have a .csv file in the same directory as the input .csv file. This output file will have the same base name as the input file but will also be prepended with a timestamp and appended with a suffix that denotes the option specified as input. 
 
@@ -82,7 +82,7 @@ Otherwise, you can quickly set up and activate a Python environment for this pro
     py -m venv venv
     ```
 
-    **On MacOS/linux (Posix):**
+    **On macOS/linux (Posix):**
     ```
     python3 -m venv venv
     ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Statistics (mean/standard deviation) can be calculated for all voxels in the nif
 
 # Instructions
 
-## 1. Create a list of NIfTI files
+### 1. Create a list of NIfTI files
 Put together a list of your NIfTI files and save this list as a .csv file where the header row says `input_file` and each subsequent row contains the full path to a NIfTI file. `batch_niistats` can read both zipped (.nii.gz) and unzipped (.nii) NIfTI files.
 
 If your files are 4D files and you would like to read a volume other than the first, also include a column called `volume_0basedindex` that specifies which volume to read using 0-based indexing (e.g. use 0 to specify the first volume, 1 for the second, etc). 0-based indexing is used in the style of python, nibabel, FSL, etc. To read multiple volumes/timepoints of a 4D nifti file, list each volume as a separate row in the input datalist.
@@ -30,7 +30,7 @@ Support for SPM syntax is intended to facilitate copying to and from SPM but is 
 
 If volumes are specified using both SPM syntax and using a `volume_0basedindex` column, the information in the `volume_0basedindex` column will be preferentially used. If no information is provided, the first volume of each image will be read.
 
-## 2. Run scripts 
+### 2. Run scripts 
 
 Open a terminal (in unix/linux/WSL) or command prompt (in Windows), activate your virtual environment (if necessary), then run the following:
 ```
@@ -53,7 +53,9 @@ The program will start by opening a file selection dialogue box. Select the .csv
 When it is done you will have a .csv file in the same directory as the input .csv file. This output file will have the same base name as the input file but will also be prepended with a timestamp and appended with a suffix that denotes the option specified as input. 
 
 # How to install
-You can install `batch_niistats` from the source repository with the command `pip install git+https://github.com/mcclaskey/batch_niistats.git@main` or by cloning the repository and installing from the local directory (recommended). To install from a local directory, first cd to where you store all repos and run the following:
+You can install `batch_niistats` from the source repository with the command `pip install git+https://github.com/mcclaskey/batch_niistats.git@main` or by cloning the repository and installing from the local directory (recommended). It is highly recommended that you run the install (by either method) inside a virtual environment (see below). 
+
+To install from a local directory, first cd to where you store all repos, create or activate your project environment (if using), and run the following:
 ```
 git clone https://github.com/mcclaskey/batch_niistats.git
 cd batch_niistats
@@ -66,23 +68,25 @@ git pull
 pip install -e .
 ```
 
-It is highly recommended that you run the install (by either method) inside a virtual environment. 
+### A note on virtual environments if you are new to python's venv (disclaimer: personal opinions included)
+If you don't already have a way to manage python environments and are looking to find one, I highly recommend Doug Hellmann's [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) tool. It's a user-friendly wrapper for virtualenv that organizes all your environments for you and makes them easy to work with. 
 
-If you do not have a way to manage environments, here is a quick way to create and activate a python environment for this project:
+Conda/Anaconda also provide tools for environment management, although I generally find these more difficult to use unless you work with them every day (in which case you probably don't need advice on venv). 
 
-Create the environment (do this only once):
-```
-python3 -m venv batch_niistats_env
-```
+Otherwise, you can quickly set up and activate a Python environment for this project using these steps:
 
-Then to activate the environment: 
+1. **Create a virtual environment** inside the project folder. Run this only once, after navigating into the project directory with `cd batch_niistats` but before the `pip install -e .` line above:
 
-On Windows:
-```
-source batch_niistats_env\Scripts\activate
-```
+    **On Windows:**
+    ```
+    py -m venv venv
+    ```
 
-For linux/unix:
-```
-source batch_niistats_env/bin/activate 
-```
+    **On MacOS/linux (Posix):**
+    ```
+    python3 -m venv venv
+    ```
+
+    This creates a virtual environment called `venv` and stores it inside a folder (also called `venv`) in the project directory.
+
+2. **Activate the environment** each time you want to work on the project, using the appropriate command for your OS and shell (see the table on [this page](https://docs.python.org/3/library/venv.html#how-venvs-work) for exact syntax), together with your environment's full path.

--- a/src/batch_niistats/cli.py
+++ b/src/batch_niistats/cli.py
@@ -30,33 +30,50 @@ def main():
     ##########################################################################
     parser = argparse.ArgumentParser(
         description=(
-            "Calculate statistics from a list of .nii files.\n\n"
+            "Calculate descriptive statistics on a list of 3D .nii files\n"
+            "and return the result as a csv file.\n\n"
+            "Specify which statistic to calculate using the 1st positional\n"
+            "argument, which must be one of the following:\n"
+            "  M: calculate mean of non-zero voxels in image\n"
+            "  m: calculate mean of all voxels in image\n"
+            "  S: calculate standard deviation of non-zero voxels in image\n"
+            "  s: calculate standard deviation of all voxels in image\n\n"
+            "Example: batch_niistats M\n\n"
             "Once the program starts, you will prompted for a list of .nii\n"
             "files to process. This list must be a CSV file with columns\n"
-            "'input_file' and (optionally) 'volume_0basedindexing'.\n\n"
-            "'input_file' lists the absolute paths to each .nii file and\n"
-            "'volume_0basedindexing' indicates the volume to read, using\n"
-            "0-based indexing (e.g. use 0 to specify the first volume and 1\n"
-            "for the second, etc).\n\n"
+            "'input_file' and (optionally) 'volume_0basedindex'. Row 1 must\n"
+            "contain column headers.\n\n"
+            "The 'input_file' column must contain the absolute paths to each"
+            "\n.nii. If your files are 4D files and you would like to read a"
+            "\nvolume other than the 1st, use the optional "
+            "'volume_0basedindex'\ncolumn to specify which volume to read "
+            "using 0-based indexing\n(e.g. use 0 to specify the first "
+            "volume, 1 for the second, etc).\nTo read multiple volumes/"
+            "timepoints of a 4D .nii file, list each\nvolume as a separate "
+            "row in the input .csv file.\n\n"
             "In lieu of a 'volume_0basedindex' column, volumes can also be\n"
-            "specified in the input_file column using SPM syntax where ',N' "
-            "is\n"
-            "placed after the filename. N indicates volume using 1-based "
-            "indexing.\n\n"
-            "The 'volume_0basedindexing' column or SPM synax can be "
-            "omitted if\n"
-            "all files are 3D NIfTIs or if you only want to calculate "
-            "statistics\n"
-            "on the first volume of each image.\n\n"
+            "specified in the input_file column using SPM syntax where ',V' "
+            "is\nplaced after the filename, e.g. ''path/to/my/file.nii,V'' "
+            "and\nindicates volume using 1-based indexing. For example,\n"
+            "''path/to/my/file.nii,1'' reads the first volume of file.nii."
+            "\n\nSupport for SPM syntax is intended to facilitate copying to "
+            "and\nfrom SPM but is otherwise not recommended. If you define\n"
+            "filenames in this way, omit single quotations at the start and\n"
+            "end of each string that are sometimes retained during SPM\n"
+            "copy/paste.\n\nThe 'volume_0basedindex' column or the SPM synax"
+            " can be omitted\nif all files are 3D NIfTIs or if you only want "
+            "to calculate\nstatistics on the first volume of each image.\n\n"
             ),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
         "option",
         choices=["M", "m", "S", "s"],
-        help="Statistical option: M (mean, nonzero), m (mean, all), "
-             "S (sd, nonzero), s (sd, all)"
-    )
+        help="Statistic to calculate:\n"
+         "  M: mean of nonzero voxels\n"
+         "  m: mean of all voxels\n"
+         "  S: stddev of nonzero voxels\n"
+         "  s: stddev of all voxels")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
These changes modify the readme and the initial argument -help text to provide clearer instructions for running and installing the package. Typos fixed in specifying the name of the volume_0basedindex column of the input .csv datalist. Fixes #35 